### PR TITLE
Support global state injection based on a request

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,23 +1,25 @@
 import express from 'express';
 import { resolve } from 'path';
-import htmlExpress, { staticIndexHandler } from '../src/index.js';
+import htmlExpress from '../src/index.js';
 
 const __dirname = resolve();
 
 const app = express();
+const viewsDir = `${__dirname}/example/public`;
 
-app.engine(
-  'js',
-  htmlExpress({
-    includesDir: 'includes',
-  }),
-);
+const { engine, staticIndexHandler } = htmlExpress({
+  viewsDir,
+  includesDir: `${viewsDir}/includes`,
+  notFoundView: 'not-found', // OPTIONAL: defaults to `404/index`
+});
+
+app.engine('js', engine);
 
 app.set('view engine', 'js');
-app.set('views', `${__dirname}/example/public`);
+app.set('views', viewsDir);
 
 // serve all other static files like CSS, images, etc
-app.use(express.static(`${__dirname}/example/public`));
+app.use(express.static(viewsDir));
 
 app.get('/hello', async function (req, res) {
   res.render('hello', {
@@ -25,12 +27,7 @@ app.get('/hello', async function (req, res) {
   });
 });
 
-// Automatically serve any index.js file as HTML in the public directory
-app.use(
-  staticIndexHandler({
-    viewsDir: `${__dirname}/example/public`,
-    notFoundView: 'not-found', // OPTIONAL: defaults to `404/index`
-  }),
-);
+// Automatically serve any index.js file as HTML in the example/public directory
+app.use(staticIndexHandler());
 
 export default app;


### PR DESCRIPTION
This changes the package setup a bit to allow injecting state into each view based upon a request. An example use-case is when auth cookie is present on a request, and you need to show things in some (or all) of your HTML views based on the existence of this cookie.  

:warning: This change is incompatible with previous versions and therefore requires a *major* version bump b/c:

1. Initializing the package with options is now required, which will then return an object that has both the `staticIndexHandler` and an `engine` function that will need to be passed to `api.use()`
   - This also makes passing these same options to `staticIndexHandler` unnecessary, although you can still pass different options to it if necessary
1. The above-mentioned options must now provide a `viewsDir` option, which will previously optional for `staticIndexHandler`

Todo:
- [x] ~Add some tests~ will add in fast follow (but have extensively tested on a prod app + and in app in examples directory)
- [x] Update README to reflect new setup